### PR TITLE
Add icon with tooltip to form-control label.

### DIFF
--- a/src/MOCK_DB_DATA/library-items/form-controls/form-control-input.ts
+++ b/src/MOCK_DB_DATA/library-items/form-controls/form-control-input.ts
@@ -5,7 +5,7 @@ export const FormControlInput: LibraryItem[] = [
   {
     id: ITEMS.FormControlInput.id,
     title: ITEMS.FormControlInput.title,
-    type: LibraryItemType.html,
+    type: LibraryItemType.angular,
     exampleHtml: getExampleHtml(),
     codeHtml: getCodeHtml(),
     documentationHtml: getDocumentationHtml(),
@@ -17,9 +17,12 @@ export const FormControlInput: LibraryItem[] = [
  */
 function getExampleHtml(): string {
   return `
-<label for="FormInput" class="form-label" aria-describedby="hjelpeTekst">Tekstfelt</label>
+<label for="FormInput" class="form-label" aria-describedby="hjelpeTekst">
+  Hjelpetekst
+  <i class="icon-question-circle icon-sm ms-1" ngbTooltip="Tooltip-tekst"></i>
+</label>
 <p class="form-text" id="hjelpeTekst">Hjelpetekst, f.eks "Valgfritt felt"</p>
-<input type="text" id="FormInput" class="form-control" placeholder="Standard tekstfelt">`;
+<input type="text" id="FormInput" class="form-control" placeholder="Standard tekstfelt" />`;
 }
 
 /*
@@ -34,5 +37,14 @@ function getCodeHtml(): string | null {
  * Return null to remove Documentation from library-item.
  */
 function getDocumentationHtml(): string | null {
-  return null;
+  return `
+<h5>Nyttige lenker</h5>
+<ul>
+    <li>
+        <a href="https://ng-bootstrap.github.io/#/components/tooltip/api">API-dokumentasjon for Tooltip-komponent</a>
+    </li>
+    <li>
+        <a href="https://ng-bootstrap.github.io/#/components/tooltip/examples">Eksempler for Tooltip-komponent</a>
+    </li>
+</ul>`;
 }

--- a/src/MOCK_DB_DATA/library-items/form-controls/form-control-input.ts
+++ b/src/MOCK_DB_DATA/library-items/form-controls/form-control-input.ts
@@ -1,5 +1,6 @@
 import { LibraryItem, LibraryItemType } from 'src/app/views/shared/models/library-item.model';
 import { LibraryItemsSharedData as ITEMS } from '../library-items-shared-data';
+import { LibraryItemConstants as CONST } from '../library-item-constants';
 
 export const FormControlInput: LibraryItem[] = [
   {
@@ -41,10 +42,10 @@ function getDocumentationHtml(): string | null {
 <h5>Nyttige lenker</h5>
 <ul>
     <li>
-        <a href="https://ng-bootstrap.github.io/#/components/tooltip/api">API-dokumentasjon for Tooltip-komponent</a>
+        <a href="${CONST.NgBootstrapComponentsBaseUrl}/tooltip/api">API-dokumentasjon for Tooltip-komponent</a>
     </li>
     <li>
-        <a href="https://ng-bootstrap.github.io/#/components/tooltip/examples">Eksempler for Tooltip-komponent</a>
+        <a href="${CONST.NgBootstrapComponentsBaseUrl}/tooltip/examples">Eksempler for Tooltip-komponent</a>
     </li>
 </ul>`;
 }

--- a/src/app/views/shared/dynamic-library-examples/example-components/form-controls/form-controls.component.html
+++ b/src/app/views/shared/dynamic-library-examples/example-components/form-controls/form-controls.component.html
@@ -55,3 +55,12 @@
     </label>
   </div>
 </ng-container>
+
+<ng-container *ngIf="itemId === items.FormControlInput.id">
+  <label for="FormInput" class="form-label" aria-describedby="hjelpeTekst">
+    Hjelpetekst
+    <i class="icon-question-circle icon-sm ms-1" ngbTooltip="Tooltip-tekst"></i>
+  </label>
+  <p class="form-text" id="hjelpeTekst">Hjelpetekst, f.eks "Valgfritt felt"</p>
+  <input type="text" id="FormInput" class="form-control" placeholder="Standard tekstfelt" />
+</ng-container>


### PR DESCRIPTION
* Added icon with ngbTooltip as an example to the form-control text component.
* Added additional examples for more advanced usecases of the tooltip.