### PR TITLE
Refactor tree view selection update logic to avoid exceeding maximum call stack size

### DIFF
--- a/projects/fhi-angular-components/CHANGELOG.md
+++ b/projects/fhi-angular-components/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
-> Apr 30, 2024
+> Mai 6, 2024
 
+* :bug: **Bugfix** Fix "exceeding maximum call stack size" if large item count in `FhiTreeViewRadioComponent` and `FhiTreeViewCheckboxComponent`
 * :tada: **Enhancement** `FhiPopoverMenu` closes on click of an item inside
 * :bug: **Bugfix** Popover menu trigger is circular when placed in table context
 
-# 4.0.2
+## 4.0.2
 
 > Mar 25, 2024
 

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -111,13 +111,12 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
           }
           item.descendantStateConfirmed = true;
         }
-        this.updateDecendantState(item.children, initialState);
-      } else if (!item.descendantStateConfirmed) {
-        item.descendantStateConfirmed = true; // I.e. has no descendants
-        this.updateDecendantState(this.items, initialState);
-      }
-      if (items.length === 1 && !item.descendantStateConfirmed) {
-        this.updateDecendantState(this.items, initialState);
+        // Only makes recursive call if there are unconfirmed descendants
+        if (!item.descendantStateConfirmed) {
+          this.updateDecendantState(item.children, initialState);
+        }
+      } else {
+        item.descendantStateConfirmed = true;
       }
     });
   }


### PR DESCRIPTION
Cleaned up and simplified the update logic within the 'fhi-tree-view-selection' component. This refinement avoids unnecessary recursion by examining the 'descendantStateConfirmed' variable before proceeding to update children items.

The previous iteration failed with a JSON-object of 12k lines of code, but the updated code seems to handle at least 130k lines (and probably alot more, but I drew a line at 10x).