### PR TITLE
Reduce max decimal places to 9

### DIFF
--- a/projects/fhi-angular-highcharts/CHANGELOG.md
+++ b/projects/fhi-angular-highcharts/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
-> Sep 12, 2024
+> Sep 13, 2024
 
+* :bug: **Bugfix** Reduce max decimal places to 9 (because Highcharts tooltips fails if 10 decimals or more)
 * :tada: **Enhancement**  Add support for showing diagram type line with multiple series even if flagged. This will also affect diagram type line with single series: data points will no longer be removed, instead the line will be broken.
   
 ## 4.3.0

--- a/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.ts
+++ b/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.ts
@@ -239,10 +239,12 @@ export class FhiAngularHighchartsComponent implements OnChanges {
     if (unit?.decimals >= 0 && unit?.decimals <= 12) {
       return unit.decimals;
     }
-    if (unit?.decimals > 12) {
-      console.warn('Max decimal places is 12 due to loss of precision at runtime!');
+    if (unit?.decimals > 9) {
+      console.warn(
+        'Max decimal places is 9 because Highcharts tooltips fails if 10 decimals or more.',
+      );
     }
-    return 12;
+    return 9;
   }
 
   private serieHasDecimalDataPoints(serie: FhiDiagramSerie): boolean {


### PR DESCRIPTION
... because Highcharts tooltips fails if 10 decimals or more
