### PR TITLE
Bugfix/tree-view-selection Make sure there is no duplicate IDs on checkboxes

### DIFF
--- a/projects/fhi-angular-components/CHANGELOG.md
+++ b/projects/fhi-angular-components/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 5.0.1
+# Unreleased
+
+> Oct 9, 2024
+
+* :bug: **Bugfix** Make sure there is no duplicate IDs on checkboxes (or radios) if more than one instance of `FhiTreeViewCheckboxComponent` or `FhiTreeViewRadioComponent` on the same page.
+
+## 5.0.1
 
 > Sep 20, 2024
 

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -217,6 +217,8 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     items.forEach((item) => {
       if (item.id === undefined) {
         item.id = this.instanceID + '-' + itemID++;
+      } else {
+        item.id = this.instanceID + '-' + item.id;
       }
       if (item.children && item.children.length > 0) {
         this.createIds(item.children, itemID * 10);


### PR DESCRIPTION
…  (or radios) if more than one instance of `FhiTreeViewCheckboxComponent` or `FhiTreeViewRadioComponent` on the same page.

This closes #716

See #628 for full description of the bug.