### PR TITLE
Make sure there is no duplicate IDs on checkboxes  (v4)

### DIFF
--- a/projects/fhi-angular-components/CHANGELOG.md
+++ b/projects/fhi-angular-components/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 4.4.2
+# Unreleased
+
+> Oct 11, 2024
+
+* :bug: **Bugfix** Make sure there is no duplicate IDs on checkboxes (or radios) if more than one instance of `FhiTreeViewCheckboxComponent` or `FhiTreeViewRadioComponent` on the same page.
+
+## 4.4.2
 
 > Sep 17, 2024
 

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -217,6 +217,8 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     items.forEach((item) => {
       if (item.id === undefined) {
         item.id = this.instanceID + '-' + itemID++;
+      } else {
+        item.id = this.instanceID + '-' + item.id;
       }
       if (item.children && item.children.length > 0) {
         this.createIds(item.children, itemID * 10);


### PR DESCRIPTION
Same as #717, but now a patch to v4

Original issue is #716 