### PR TITLE
Enhancement/ignore unknown diagram types

### DIFF
--- a/projects/fhi-angular-highcharts/CHANGELOG.md
+++ b/projects/fhi-angular-highcharts/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
-> Dec 18, 2024
+> Jan 3, 2025
 
 * :tada: **Enhancement** Add option `categoryAxis` to `FhiDiagramOptions`, and add support for setting the category axis title [(#763)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/763)
 * :tada: **Enhancement** Update qualitative color series [(#771)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/771)
 * :tada: **Enhancement** Use cloneDeep() to make diagramOptions immutable [(#765)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/765)
 * :tada: **Enhancement** Rewrite decimals once instead of formatting decimals in table template and tooltip [(#773)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/773)
+* :tada: **Enhancement** Add test for illegal diagram type, and for multiple equal diagram types [(#776)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/776)
 
 ## 5.2.0
 

--- a/projects/fhi-angular-highcharts/src/lib/services/diagram-type-group.service.ts
+++ b/projects/fhi-angular-highcharts/src/lib/services/diagram-type-group.service.ts
@@ -149,16 +149,34 @@ export class DiagramTypeGroupService {
 
     if (isChart) {
       items.chartTypes.forEach((id) => {
-        group.children.push(ChartTypes.find((type) => type.id === id));
+        this.updateDiagramTypeGroup(id, group, ChartTypes, 'Chart');
       });
     }
     if (isMap) {
       items.mapTypes.forEach((id) => {
-        group.children.push(MapTypes.find((type) => type.id === id));
+        this.updateDiagramTypeGroup(id, group, MapTypes, 'Map');
       });
     }
 
     return group;
+  }
+
+  private updateDiagramTypeGroup(
+    id: string,
+    group: DiagramTypeGroup,
+    Types: DiagramType[],
+    typeName: string,
+  ) {
+    const type = Types.find((type) => type.id === id);
+    const typeExist = group.children.find((type) => type.id === id);
+
+    if (type !== undefined && typeExist === undefined) {
+      group.children.push(type);
+    } else if (typeExist) {
+      console.warn(typeName + ' type id: "' + id + '" is listed more than once.');
+    } else {
+      console.warn(typeName + ' type id: "' + id + '" is not valid.');
+    }
   }
 
   private diagramTypeIsActive(diagramType: DiagramType, groups: DiagramTypeGroup[]): boolean {


### PR DESCRIPTION
Add test for illegal diagram type, and for multiple equal diagram types.

This closes #767 