### PR TITLE
Bugfix/tree view selection immutable ids

### DIFF
--- a/projects/fhi-angular-components/CHANGELOG.md
+++ b/projects/fhi-angular-components/CHANGELOG.md
@@ -3,7 +3,7 @@
 > Jan 8, 2025
 
 * :bug: **Bugfix** Make selected value visible before ng-select is touched (in `FhiAutosuggestComponent`) [(#762)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/762)
-* :bug: **Bugfix** In `FhiTreeViewSelectionComponent`, add property internal, and make sure custom properties set by consumer (eg. `FhiTreeViewSelectionItem.id`)  are treated as immutable [(#778)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/778)
+* :bug: **Bugfix** In `FhiTreeViewSelectionComponent`, add property internal, and make sure custom properties set by consumer (e.g. `FhiTreeViewSelectionItem.id`)  are treated as immutable [(#778)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/778)
 * :tada: **Enhancement** In `FhiTreeViewSelectionComponent`, start search while typing, and at first character [(#769)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/769)
 
 ## 5.2.0

--- a/projects/fhi-angular-components/CHANGELOG.md
+++ b/projects/fhi-angular-components/CHANGELOG.md
@@ -3,7 +3,7 @@
 > Jan 8, 2025
 
 * :bug: **Bugfix** Make selected value visible before ng-select is touched (in `FhiAutosuggestComponent`) [(#762)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/762)
-* :bug: **Bugfix** In `FhiTreeViewSelectionComponent`, add property internal, and make sure custom properties set by consumer (e.g. `FhiTreeViewSelectionItem.id`)  are treated as immutable [(#778)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/778)
+* :bug: **Bugfix** In `FhiTreeViewSelectionComponent`, add property internal, and make sure property `FhiTreeViewSelectionItem.id` set by consumer is treated as immutable [(#778)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/778)
 * :tada: **Enhancement** In `FhiTreeViewSelectionComponent`, start search while typing, and at first character [(#769)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/769)
 
 ## 5.2.0

--- a/projects/fhi-angular-components/CHANGELOG.md
+++ b/projects/fhi-angular-components/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 
-> Dec 18, 2024
+> Jan 8, 2025
 
 * :bug: **Bugfix** Make selected value visible before ng-select is touched (in `FhiAutosuggestComponent`) [(#762)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/762)
-* :tada: **Enhancement** Start search while typing, and at first character, in `FhiTreeViewSelectionComponent` [(#769)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/769)
+* :bug: **Bugfix** In `FhiTreeViewSelectionComponent`, add property internal, and make sure custom properties set by consumer (eg. `FhiTreeViewSelectionItem.id`)  are treated as immutable [(#778)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/778)
+* :tada: **Enhancement** In `FhiTreeViewSelectionComponent`, start search while typing, and at first character [(#769)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/769)
 
 ## 5.2.0
 

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/README.md
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/README.md
@@ -25,9 +25,8 @@
 | Property                   | Type                         | Default | Required | Description |
 | -------------------------- | ---------------------------- | ------- | -------- | ----------- |
 | `children`                 | `FhiTreeViewSelectionItem[]` | -       | no       | Recursively add items to the tree. |
+| `id`                       | `number \| string`           | -       | no       | Optional item id, not used by the component (kept in the interface for backwards compatibility). |
 | `isChecked`                | `boolean`                    | -       | no       | Whether the item is checked or not. |
 | `isExpanded`               | `boolean`                    | -       | no       | Whether the item is expanded or not. |
 | `hasCheckedDescendant`     | `boolean`                    | -       | no       | Whether the item has checked descendant or not. |
 | `name`                     | `string`                     | -       | yes      | Used as value in the form check label. |
-| `[key: string]`            | `unknown`                    | -       | no       | Custom properties (e.g. id). All custom properties are treated as immutable. |
-| `internal`                 | NA                           | -       | no       | Properties used internally by the component. If property `internal` is set it will always be overwritten. |

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/README.md
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/README.md
@@ -29,5 +29,5 @@
 | `isExpanded`               | `boolean`                    | -       | no       | Whether the item is expanded or not. |
 | `hasCheckedDescendant`     | `boolean`                    | -       | no       | Whether the item has checked descendant or not. |
 | `name`                     | `string`                     | -       | yes      | Used as value in the form check label. |
-| `[key: string]`            | `unknown`                    | -       | no       | Custom properties (eg. id). All custom properties are treated as immutable. |
+| `[key: string]`            | `unknown`                    | -       | no       | Custom properties (e.g. id). All custom properties are treated as immutable. |
 | `internal`                 | NA                           | -       | no       | Properties used internally by the component. If property `internal` is set it will always be overwritten. |

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/README.md
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/README.md
@@ -25,8 +25,9 @@
 | Property                   | Type                         | Default | Required | Description |
 | -------------------------- | ---------------------------- | ------- | -------- | ----------- |
 | `children`                 | `FhiTreeViewSelectionItem[]` | -       | no       | Recursively add items to the tree. |
-| `id`                       | `number \| string`           | -       | no       | Custom id's. Id's are added automatically if not set in item. |
 | `isChecked`                | `boolean`                    | -       | no       | Whether the item is checked or not. |
 | `isExpanded`               | `boolean`                    | -       | no       | Whether the item is expanded or not. |
 | `hasCheckedDescendant`     | `boolean`                    | -       | no       | Whether the item has checked descendant or not. |
 | `name`                     | `string`                     | -       | yes      | Used as value in the form check label. |
+| `[key: string]`            | `unknown`                    | -       | no       | Custom properties (eg. id). All custom properties are treated as immutable. |
+| `internal`                 | NA                           | -       | no       | Properties used internally by the component. If property `internal` is set it will always be overwritten. |

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item-internal.model.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item-internal.model.ts
@@ -1,0 +1,10 @@
+export interface FhiTreeViewSelectionItemInternal {
+  children?: FhiTreeViewSelectionItemInternal[];
+  internal?: {
+    id: string;
+  };
+  isChecked?: boolean;
+  isExpanded?: boolean;
+  hasCheckedDescendant?: boolean;
+  name: string;
+}

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item-internal.model.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item-internal.model.ts
@@ -1,0 +1,5 @@
+import { FhiTreeViewSelectionItem } from './fhi-tree-view-selection-item.model';
+
+export interface FhiTreeViewSelectionItemInternal extends FhiTreeViewSelectionItem {
+  itemID?: string;
+}

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item-internal.model.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item-internal.model.ts
@@ -1,5 +1,0 @@
-import { FhiTreeViewSelectionItem } from './fhi-tree-view-selection-item.model';
-
-export interface FhiTreeViewSelectionItemInternal extends FhiTreeViewSelectionItem {
-  itemID?: string;
-}

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item.model.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item.model.ts
@@ -4,5 +4,4 @@ export interface FhiTreeViewSelectionItem
   extends Omit<FhiTreeViewSelectionItemInternal, 'internal'> {
   children?: FhiTreeViewSelectionItem[];
   id?: number | string;
-  [key: string]: unknown;
 }

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item.model.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item.model.ts
@@ -1,13 +1,8 @@
-interface InternalItemProps {
-  id: string;
-}
+import { FhiTreeViewSelectionItemInternal } from './fhi-tree-view-selection-item-internal.model';
 
-export interface FhiTreeViewSelectionItem {
+export interface FhiTreeViewSelectionItem
+  extends Omit<FhiTreeViewSelectionItemInternal, 'internal'> {
   children?: FhiTreeViewSelectionItem[];
-  internal?: InternalItemProps;
-  isChecked?: boolean;
-  isExpanded?: boolean;
-  hasCheckedDescendant?: boolean;
-  name: string;
+  id?: number | string;
   [key: string]: unknown;
 }

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item.model.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection-item.model.ts
@@ -1,8 +1,13 @@
+interface InternalItemProps {
+  id: string;
+}
+
 export interface FhiTreeViewSelectionItem {
   children?: FhiTreeViewSelectionItem[];
-  id?: number | string;
+  internal?: InternalItemProps;
   isChecked?: boolean;
   isExpanded?: boolean;
   hasCheckedDescendant?: boolean;
   name: string;
+  [key: string]: unknown;
 }

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.html
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.html
@@ -80,7 +80,7 @@
       <ng-container *ngIf="(item.isExpanded && item.children) || (item.children && itemsFilteredIsLoaded)">
         <div class="fhi-tree-view-checkbox__nested-group">
           <ng-container
-            *ngTemplateOutlet="checkboxItems; context: { items: item.children, listID: item.id }"
+            *ngTemplateOutlet="checkboxItems; context: { items: item.children, listID: item.itemID }"
           ></ng-container>
         </div>
       </ng-container>
@@ -111,7 +111,7 @@
   <button
     class="fhi-tree-view-checkbox__toggler"
     [attr.aria-label]="'Toggle ' + item.name"
-    [attr.aria-controls]="'list-' + item.id"
+    [attr.aria-controls]="'list-' + item.itemID"
     [attr.aria-haspopup]="'tree'"
     [attr.aria-expanded]="item.isExpanded"
     (click)="toggleExpanded(item)"
@@ -134,14 +134,14 @@
       class="form-check-input"
       type="checkbox"
       value=""
-      [id]="'check-input-' + item.id"
+      [id]="'check-input-' + item.itemID"
       [checked]="item.isChecked"
-      (click)="toggleChecked(item.id)"
+      (click)="toggleChecked(item.itemID)"
     />
     <label
       class="form-check-label"
-      [for]="'check-input-' + item.id"
-      [id]="'label-' + item.id"
+      [for]="'check-input-' + item.itemID"
+      [id]="'label-' + item.itemID"
       [innerHTML]="item.name"
     ></label>
   </div>
@@ -153,14 +153,14 @@
       class="form-check-input"
       type="radio"
       [name]="name"
-      [id]="name + '-' + item.id"
+      [id]="name + '-' + item.itemID"
       [checked]="item.isChecked"
-      (change)="toggleChecked(item.id, false, false)"
+      (change)="toggleChecked(item.itemID, false, false)"
     />
     <label
       class="form-check-label"
-      [for]="name + '-' + item.id"
-      [id]="'label-' + item.id"
+      [for]="name + '-' + item.itemID"
+      [id]="'label-' + item.itemID"
       [innerHTML]="item.name"
     ></label>
   </div>

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.html
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.html
@@ -80,7 +80,7 @@
       <ng-container *ngIf="(item.isExpanded && item.children) || (item.children && itemsFilteredIsLoaded)">
         <div class="fhi-tree-view-checkbox__nested-group">
           <ng-container
-            *ngTemplateOutlet="checkboxItems; context: { items: item.children, listID: item.itemID }"
+            *ngTemplateOutlet="checkboxItems; context: { items: item.children, listID: item.internal?.id }"
           ></ng-container>
         </div>
       </ng-container>
@@ -111,7 +111,7 @@
   <button
     class="fhi-tree-view-checkbox__toggler"
     [attr.aria-label]="'Toggle ' + item.name"
-    [attr.aria-controls]="'list-' + item.itemID"
+    [attr.aria-controls]="'list-' + item.internal?.id"
     [attr.aria-haspopup]="'tree'"
     [attr.aria-expanded]="item.isExpanded"
     (click)="toggleExpanded(item)"
@@ -134,14 +134,14 @@
       class="form-check-input"
       type="checkbox"
       value=""
-      [id]="'check-input-' + item.itemID"
+      [id]="'check-input-' + item.internal?.id"
       [checked]="item.isChecked"
-      (click)="toggleChecked(item.itemID)"
+      (click)="toggleChecked(item.internal?.id)"
     />
     <label
       class="form-check-label"
-      [for]="'check-input-' + item.itemID"
-      [id]="'label-' + item.itemID"
+      [for]="'check-input-' + item.internal?.id"
+      [id]="'label-' + item.internal?.id"
       [innerHTML]="item.name"
     ></label>
   </div>
@@ -153,14 +153,14 @@
       class="form-check-input"
       type="radio"
       [name]="name"
-      [id]="name + '-' + item.itemID"
+      [id]="name + '-' + item.internal?.id"
       [checked]="item.isChecked"
-      (change)="toggleChecked(item.itemID, false, false)"
+      (change)="toggleChecked(item.internal?.id, false, false)"
     />
     <label
       class="form-check-label"
-      [for]="name + '-' + item.itemID"
-      [id]="'label-' + item.itemID"
+      [for]="name + '-' + item.internal?.id"
+      [id]="'label-' + item.internal?.id"
       [innerHTML]="item.name"
     ></label>
   </div>

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -15,7 +15,8 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { FhiTreeViewSelectionItem as Item } from './fhi-tree-view-selection-item.model';
+import { FhiTreeViewSelectionItem } from './fhi-tree-view-selection-item.model';
+import { FhiTreeViewSelectionItemInternal as Item } from './fhi-tree-view-selection-item-internal.model';
 import { FhiTreeViewSelectionItemState } from './fhi-tree-view-selection-item-state.model';
 import { debounceTime, Observable, of, Subject, switchMap } from 'rxjs';
 import { cloneDeep } from 'lodash-es';
@@ -32,12 +33,12 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
   @Input() enableCheckAll = false;
   @Input() filterLabel!: string;
   @Input() singleSelection = false;
-  @Input({ required: true }) items!: Item[];
+  @Input({ required: true }) items!: FhiTreeViewSelectionItem[];
   @Input() name!: string;
   @Input() enableFilter = false;
   @Input() placeholder = 'Søk';
 
-  @Output() itemsChange = new EventEmitter<Item[]>();
+  @Output() itemsChange = new EventEmitter<FhiTreeViewSelectionItem[]>();
 
   @ViewChild('checkboxList') checkboxListRef: ElementRef;
   @ViewChild('resultListWrapper') resultListWrapperRef: ElementRef;
@@ -76,7 +77,7 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
       this.createIds(this.items);
       this.updateDecendantState(this.items, true);
     }
-    this.itemsChange.emit(this.items);
+    this.itemsChange.emit(this.items as FhiTreeViewSelectionItem[]);
   }
 
   onSearchTermChange(searchTerm: string) {
@@ -98,7 +99,7 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     this.updateCheckedState(id, this.items, multiToggle, checkAll);
     this.updateDecendantState(this.items, false);
     if (!multiToggle) {
-      this.itemsChange.emit(this.items);
+      this.itemsChange.emit(this.items as FhiTreeViewSelectionItem[]);
     }
   }
 
@@ -106,14 +107,14 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     items.forEach((item) => {
       this.toggleChecked(item.internal.id, true, true);
     });
-    this.itemsChange.emit(this.items);
+    this.itemsChange.emit(this.items as FhiTreeViewSelectionItem[]);
   }
 
   uncheckAll(items: Item[]) {
     items.forEach((item) => {
       this.toggleChecked(item.internal.id, true);
     });
-    this.itemsChange.emit(this.items);
+    this.itemsChange.emit(this.items as FhiTreeViewSelectionItem[]);
   }
 
   allItemsChecked(items: Item[]): boolean {

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -15,7 +15,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { FhiTreeViewSelectionItem as Item } from './fhi-tree-view-selection-item.model';
+import { FhiTreeViewSelectionItemInternal as Item } from './fhi-tree-view-selection-item-internal.model';
 import { FhiTreeViewSelectionItemState } from './fhi-tree-view-selection-item-state.model';
 import { debounceTime, Observable, of, Subject, switchMap } from 'rxjs';
 import { cloneDeep } from 'lodash-es';
@@ -245,11 +245,8 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
   private createIds(items: Item[], id?: number) {
     let itemID = id ? id : 0;
     items.forEach((item) => {
-      if (item.id === undefined) {
-        item.id = this.instanceID + '-' + itemID++;
-      } else {
-        item.id = this.instanceID + '-' + item.id;
-      }
+      item.itemID = this.instanceID + '-' + itemID++;
+
       if (item.children && item.children.length > 0) {
         this.createIds(item.children, itemID * 10);
       }

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -94,7 +94,7 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     item.isExpanded = !item.isExpanded;
   }
 
-  toggleChecked(id: number | string, multiToggle = false, checkAll = false) {
+  toggleChecked(id: string, multiToggle = false, checkAll = false) {
     this.updateCheckedState(id, this.items, multiToggle, checkAll);
     this.updateDecendantState(this.items, false);
     if (!multiToggle) {
@@ -104,14 +104,14 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
 
   checkAll(items: Item[]) {
     items.forEach((item) => {
-      this.toggleChecked(item.id, true, true);
+      this.toggleChecked(item.itemID, true, true);
     });
     this.itemsChange.emit(this.items);
   }
 
   uncheckAll(items: Item[]) {
     items.forEach((item) => {
-      this.toggleChecked(item.id, true);
+      this.toggleChecked(item.itemID, true);
     });
     this.itemsChange.emit(this.items);
   }
@@ -171,14 +171,9 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     }, []);
   }
 
-  private updateCheckedState(
-    id: number | string,
-    items: Item[],
-    multiToggle: boolean,
-    checkAll: boolean,
-  ) {
+  private updateCheckedState(id: string, items: Item[], multiToggle: boolean, checkAll: boolean) {
     items.forEach((item) => {
-      if (item.id === id) {
+      if (item.itemID === id) {
         if (multiToggle) {
           checkAll ? (item.isChecked = true) : (item.isChecked = false);
         } else if (!this.singleSelection) {
@@ -187,7 +182,7 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
           item.isChecked = true;
         }
       }
-      if (this.singleSelection && item.id !== id) {
+      if (this.singleSelection && item.itemID !== id) {
         item.isChecked = null;
       }
       if (item.children && item.children.length > 0) {
@@ -243,12 +238,13 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
   }
 
   private createIds(items: Item[], id?: number) {
-    let itemID = id ? id : 0;
+    id = id ? id : 0;
+
     items.forEach((item) => {
-      item.itemID = this.instanceID + '-' + itemID++;
+      item.itemID = this.instanceID + '-' + ++id;
 
       if (item.children && item.children.length > 0) {
-        this.createIds(item.children, itemID * 10);
+        this.createIds(item.children, id * 10);
       }
     });
   }

--- a/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
+++ b/projects/fhi-angular-components/src/lib/fhi-tree-view-selection/fhi-tree-view-selection.component.ts
@@ -15,7 +15,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { FhiTreeViewSelectionItemInternal as Item } from './fhi-tree-view-selection-item-internal.model';
+import { FhiTreeViewSelectionItem as Item } from './fhi-tree-view-selection-item.model';
 import { FhiTreeViewSelectionItemState } from './fhi-tree-view-selection-item-state.model';
 import { debounceTime, Observable, of, Subject, switchMap } from 'rxjs';
 import { cloneDeep } from 'lodash-es';
@@ -104,14 +104,14 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
 
   checkAll(items: Item[]) {
     items.forEach((item) => {
-      this.toggleChecked(item.itemID, true, true);
+      this.toggleChecked(item.internal.id, true, true);
     });
     this.itemsChange.emit(this.items);
   }
 
   uncheckAll(items: Item[]) {
     items.forEach((item) => {
-      this.toggleChecked(item.itemID, true);
+      this.toggleChecked(item.internal.id, true);
     });
     this.itemsChange.emit(this.items);
   }
@@ -173,7 +173,7 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
 
   private updateCheckedState(id: string, items: Item[], multiToggle: boolean, checkAll: boolean) {
     items.forEach((item) => {
-      if (item.itemID === id) {
+      if (item.internal.id === id) {
         if (multiToggle) {
           checkAll ? (item.isChecked = true) : (item.isChecked = false);
         } else if (!this.singleSelection) {
@@ -182,7 +182,7 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
           item.isChecked = true;
         }
       }
-      if (this.singleSelection && item.itemID !== id) {
+      if (this.singleSelection && item.internal.id !== id) {
         item.isChecked = null;
       }
       if (item.children && item.children.length > 0) {
@@ -241,8 +241,9 @@ export class FhiTreeViewSelectionComponent implements OnInit, OnChanges {
     id = id ? id : 0;
 
     items.forEach((item) => {
-      item.itemID = this.instanceID + '-' + ++id;
-
+      item.internal = {
+        id: this.instanceID + '-' + ++id,
+      };
       if (item.children && item.children.length > 0) {
         this.createIds(item.children, id * 10);
       }

--- a/src/app/views/shared/dynamic-library-examples/example-components/tree-views/tree-views.component.ts
+++ b/src/app/views/shared/dynamic-library-examples/example-components/tree-views/tree-views.component.ts
@@ -30,9 +30,6 @@ export class TreeViewsComponent implements OnInit {
   }
 
   onCheckboxChange(items: FhiTreeViewSelectionItem[]) {
-    console.log('Property "foo" is kept:', items[0]['foo']);
-    console.log('Property "internal" is overwritten:', items[0]['internal']);
-
     this.itemsCheck = items;
   }
 
@@ -86,8 +83,6 @@ export class TreeViewsComponent implements OnInit {
   private getTreeViewSelectionItems(): FhiTreeViewSelectionItem[] {
     return [
       {
-        foo: 'bar',
-        internal: 'baz',
         name: 'For utviklere',
         children: [
           {

--- a/src/app/views/shared/dynamic-library-examples/example-components/tree-views/tree-views.component.ts
+++ b/src/app/views/shared/dynamic-library-examples/example-components/tree-views/tree-views.component.ts
@@ -30,6 +30,8 @@ export class TreeViewsComponent implements OnInit {
   }
 
   onCheckboxChange(items: FhiTreeViewSelectionItem[]) {
+    console.log('items', items[0]);
+
     this.itemsCheck = items;
   }
 
@@ -83,6 +85,7 @@ export class TreeViewsComponent implements OnInit {
   private getTreeViewSelectionItems(): FhiTreeViewSelectionItem[] {
     return [
       {
+        internal: 'this will be overwritten...',
         name: 'For utviklere',
         children: [
           {

--- a/src/app/views/shared/dynamic-library-examples/example-components/tree-views/tree-views.component.ts
+++ b/src/app/views/shared/dynamic-library-examples/example-components/tree-views/tree-views.component.ts
@@ -30,7 +30,8 @@ export class TreeViewsComponent implements OnInit {
   }
 
   onCheckboxChange(items: FhiTreeViewSelectionItem[]) {
-    console.log('items', items[0]);
+    console.log('Property "foo" is kept:', items[0]['foo']);
+    console.log('Property "internal" is overwritten:', items[0]['internal']);
 
     this.itemsCheck = items;
   }
@@ -85,7 +86,8 @@ export class TreeViewsComponent implements OnInit {
   private getTreeViewSelectionItems(): FhiTreeViewSelectionItem[] {
     return [
       {
-        internal: 'this will be overwritten...',
+        foo: 'bar',
+        internal: 'baz',
         name: 'For utviklere',
         children: [
           {


### PR DESCRIPTION
Add property internal, and make sure custom properties set by consumer (e.g. `FhiTreeViewSelectionItem.id`)  are treated as immutable.

This closes #772 