### PR TITLE
Use single chart instance for fullscreen

### DIFF
--- a/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.html
+++ b/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.html
@@ -22,7 +22,7 @@
       <p class="mb-4">{{ diagramOptionsInternal.description }}</p>
     }
 
-    @if (showDiagramTypeNav || showDownloadButton || showFullScreenButton || showMetadataButton) {
+    @if (!isFullscreen && (showDiagramTypeNav || showDownloadButton || showFullScreenButton || showMetadataButton)) {
       <ng-container *ngTemplateOutlet="diagramControls" />
     }
     @if (showDiagramTypeDisabledWarning) {

--- a/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.html
+++ b/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.html
@@ -2,6 +2,22 @@
   <article [class.fhi-diagram--fullscreen]="isFullscreen">
     <h1 class="h3 mb-3">{{ diagramOptionsInternal.title }}</h1>
 
+    @if (isFullscreen) {
+      <button
+        type="button"
+        class="btn-close fhi-diagram-fullscreen__close"
+        aria-label="Lukk fullskjerm"
+        (click)="closeFullscreen()"
+      ></button>
+      <button
+        type="button"
+        class="btn fhi-btn-secondary fhi-diagram-fullscreen__close-bottom"
+        (click)="closeFullscreen()"
+      >
+        Lukk
+      </button>
+    }
+
     @if (diagramOptionsInternal.description) {
       <p class="mb-4">{{ diagramOptionsInternal.description }}</p>
     }
@@ -61,14 +77,14 @@
             </button>
           }
 
-          @if (showFullScreenButton && !showDiagramTypeDisabledWarning) {
+          @if (showFullScreenButton && !showDiagramTypeDisabledWarning && !isFullscreen) {
             <button
               type="button"
               class="btn fhi-btn-icon fhi-btn-icon--circular"
               (click)="toggleFullscreen()"
-              [attr.aria-pressed]="isFullscreen"
+              aria-label="Fullskjerm"
             >
-              <i class="icon-arrows-fullscreen"></i>
+              <i class="icon-arrows-fullscreen" aria-hidden="true"></i>
               <span class="visually-hidden">Fullskjerm</span>
             </button>
           }

--- a/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.html
+++ b/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.html
@@ -1,5 +1,5 @@
 @if (diagramOptionsInternal) {
-  <article>
+  <article [class.fhi-diagram--fullscreen]="isFullscreen">
     <h1 class="h3 mb-3">{{ diagramOptionsInternal.title }}</h1>
 
     @if (diagramOptionsInternal.description) {
@@ -60,9 +60,19 @@
               <span class="btn__text">Om dataene</span>
             </button>
           }
+
           @if (showFullScreenButton && !showDiagramTypeDisabledWarning) {
-            <ng-container *ngTemplateOutlet="diagramModal" />
+            <button
+              type="button"
+              class="btn fhi-btn-icon fhi-btn-icon--circular"
+              (click)="toggleFullscreen()"
+              [attr.aria-pressed]="isFullscreen"
+            >
+              <i class="icon-arrows-fullscreen"></i>
+              <span class="visually-hidden">Fullskjerm</span>
+            </button>
           }
+
           @if (showDownloadButton) {
             <div class="ms-auto">
               <fhi-popover-menu
@@ -74,9 +84,7 @@
           @if (showTableOrientationButton) {
             <div class="ms-auto">
               <fhi-popover-menu
-                [items]="[
-                  { name: 'Bytt rader og kolonner', action: 'changeTableOrientation', icon: 'table' },
-                ]"
+                [items]="[{ name: 'Bytt rader og kolonner', action: 'changeTableOrientation', icon: 'table' }]"
                 (actionEvent)="onControlsPopoverMenuAction($event)"
               ></fhi-popover-menu>
             </div>
@@ -86,7 +94,8 @@
     </div>
   </ng-template>
 
-  <ng-template #diagramModal>
+  <!--Fullscreen modal removed - using CSS fullscreen instead-->
+  <!--<ng-template #diagramModal>
     <fhi-modal
       [openModalButtonClass]="'fhi-btn-icon fhi-btn-icon--circular'"
       [modalTitle]="diagramOptionsInternal.title"
@@ -103,7 +112,7 @@
         <ng-container *ngTemplateOutlet="diagramAndFooter" />
       </ng-container>
     </fhi-modal>
-  </ng-template>
+  </ng-template>*-->
 
   <ng-template #chart>
     <div class="fhi-highcharts-chart">

--- a/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.ts
+++ b/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.ts
@@ -58,6 +58,7 @@ enum ControlsPopoverMenuActions {
 export class FhiAngularHighchartsComponent implements OnChanges {
   private allSerieNames: string[] = [];
   private chartInstance!: Chart;
+  isFullscreen = false;
 
   @Input({ required: true }) diagramOptions!: FhiDiagramOptions;
 
@@ -137,6 +138,23 @@ export class FhiAngularHighchartsComponent implements OnChanges {
     this.chartInstance = chartInstance;
   }
 
+  toggleFullscreen() {
+    this.isFullscreen = !this.isFullscreen;
+
+    setTimeout(() => {
+      if (this.chartInstance) {
+        this.chartInstance.reflow();
+      }
+    }, 0);
+
+    this.changeDetector.detectChanges();
+  }
+
+  closeFullscreen() {
+    if (!this.isFullscreen) return;
+    this.toggleFullscreen();
+  }
+
   onControlsPopoverMenuAction(actionName: string) {
     if (actionName === ControlsPopoverMenuActions.downloadSvg) {
       this.downloadService.downloadImage(
@@ -197,6 +215,7 @@ export class FhiAngularHighchartsComponent implements OnChanges {
     this.allSerieNames = [];
     this.flaggedSeries = [];
     this.metadataForSeriesService.resetMetadataForSeries();
+    this.isFullscreen = false;
   }
 
   private formatSerieName(name: string | Array<string>): string {

--- a/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.ts
+++ b/projects/fhi-angular-highcharts/src/lib/fhi-angular-highcharts.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  HostListener,
   Input,
   OnChanges,
   Output,
@@ -58,6 +59,7 @@ enum ControlsPopoverMenuActions {
 export class FhiAngularHighchartsComponent implements OnChanges {
   private allSerieNames: string[] = [];
   private chartInstance!: Chart;
+
   isFullscreen = false;
 
   @Input({ required: true }) diagramOptions!: FhiDiagramOptions;
@@ -140,11 +142,10 @@ export class FhiAngularHighchartsComponent implements OnChanges {
 
   toggleFullscreen() {
     this.isFullscreen = !this.isFullscreen;
+    document.body.style.overflow = this.isFullscreen ? 'hidden' : '';
 
     setTimeout(() => {
-      if (this.chartInstance) {
-        this.chartInstance.reflow();
-      }
+      this.chartInstance?.reflow();
     }, 0);
 
     this.changeDetector.detectChanges();
@@ -153,6 +154,17 @@ export class FhiAngularHighchartsComponent implements OnChanges {
   closeFullscreen() {
     if (!this.isFullscreen) return;
     this.toggleFullscreen();
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onDocumentKeydown(event: Event) {
+    if (!this.isFullscreen) return;
+
+    const keyboardEvent = event as KeyboardEvent;
+    if (keyboardEvent.key !== 'Escape') return;
+
+    keyboardEvent.preventDefault();
+    this.closeFullscreen();
   }
 
   onControlsPopoverMenuAction(actionName: string) {
@@ -215,6 +227,7 @@ export class FhiAngularHighchartsComponent implements OnChanges {
     this.allSerieNames = [];
     this.flaggedSeries = [];
     this.metadataForSeriesService.resetMetadataForSeries();
+
     this.isFullscreen = false;
   }
 

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -56,45 +56,50 @@ $square: 1;
     z-index: 1050;
     background: #fff;
     overflow: auto;
-
-    .fhi-highcharts-chart,
-    .fhi-highcharts-chart--map {
-        max-width: none;
-        width: 100%;
-    }
-
-    .fhi-highcharts-chart highcharts-chart,
-    .fhi-highcharts-chart--map highcharts-chart {
-        max-height: none;
-        aspect-ratio: auto;
-        height: 80vh;
-    }
+    box-sizing: border-box;
+    padding: 2rem;
+    padding-bottom: 88px;
 }
 
-@media (max-width: 576px) {
+.fhi-diagram--fullscreen h1 {
+    padding-right: 40px;
+}
+
+.fhi-diagram--fullscreen h1.h3 {
+    font-size: 2.25rem;
+    padding-bottom: 2.9rem;
+}
+
+.fhi-diagram--fullscreen .fhi-diagram-fullscreen__close {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    left: auto;
+    z-index: 1060;
+}
+
+.fhi-diagram--fullscreen .fhi-diagram-fullscreen__close-bottom {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    left: auto;
+    z-index: 1060;
+}
+
+@media (max-width: 600px) {
     .fhi-diagram--fullscreen {
-        padding: 16px;
-        padding-bottom: 96px; // plass til "Lukk"
+        padding: 12px;
+        padding-bottom: 96px;
     }
 
-    .fhi-diagram--fullscreen {
-        .fhi-highcharts-chart highcharts-chart,
-        .fhi-highcharts-chart--map highcharts-chart {
-            height: 65vh;
-        }
-    }
-
-    .fhi-diagram-fullscreen__close {
+    .fhi-diagram--fullscreen .fhi-diagram-fullscreen__close {
         top: 12px;
         right: 12px;
-        transform: scale(1.1);
     }
 
-    .fhi-diagram-fullscreen__close-bottom {
-        left: 16px;
-        right: 16px;
-        bottom: 16px;
-        width: auto;
-        max-width: none;
+    .fhi-diagram--fullscreen .fhi-diagram-fullscreen__close-bottom {
+        left: 12px;
+        right: 12px;
+        bottom: 12px;
     }
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -69,4 +69,19 @@ $square: 1;
         aspect-ratio: auto;
         height: 80vh;
     }
+
+    .fhi-diagram-fullscreen__close {
+        position: fixed;
+        top: calc(env(safe-area-inset-top) + clamp(12px, 2vw, 24px));
+        right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
+        z-index: 1060;
+    }
+
+    /* "Lukk" nede til høyre */
+    .fhi-diagram-fullscreen__close-bottom {
+        position: fixed;
+        right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
+        bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 2vw, 24px));
+        z-index: 1060;
+    }
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -55,7 +55,6 @@ $square: 1;
     inset: 0;
     z-index: 1050;
     background: #fff;
-    padding: 1rem;
     overflow: auto;
 
     .fhi-highcharts-chart,

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -50,7 +50,7 @@ $square: 1;
     }
 }
 
-.fhi-diagram--fullscreen {
+/*.fhi-diagram--fullscreen {
     position: fixed;
     inset: 0;
     z-index: 1050;
@@ -77,11 +77,38 @@ $square: 1;
         z-index: 1060;
     }
 
-    /* "Lukk" nede til høyre */
     .fhi-diagram-fullscreen__close-bottom {
         position: fixed;
         right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
         bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 2vw, 24px));
         z-index: 1060;
     }
+}*/
+
+.fhi-diagram--fullscreen {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    background: #fff;
+
+    box-sizing: border-box;
+    padding: clamp(16px, 2vw, 32px);
+
+    padding-bottom: calc(clamp(16px, 2vw, 32px) + 64px);
+
+    overflow: auto;
+}
+
+.fhi-diagram-fullscreen__close {
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + clamp(12px, 2vw, 24px));
+    right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
+    z-index: 1060;
+}
+
+.fhi-diagram-fullscreen__close-bottom {
+    position: fixed;
+    right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
+    bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 2vw, 24px));
+    z-index: 1060;
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -50,7 +50,7 @@ $square: 1;
     }
 }
 
-/*.fhi-diagram--fullscreen {
+.fhi-diagram--fullscreen {
     position: fixed;
     inset: 0;
     z-index: 1050;
@@ -69,33 +69,4 @@ $square: 1;
         aspect-ratio: auto;
         height: 80vh;
     }
-}*/
-
-.fhi-diagram--fullscreen {
-    position: fixed;
-    inset: 0;
-    z-index: 1050;
-    background: #fff;
-
-    width: 100vw;
-    height: 100dvh;
-    overflow: auto;
-    overflow-x: hidden;
-
-    padding-top: calc(env(safe-area-inset-top) + 1rem);
-    padding-bottom: calc(env(safe-area-inset-bottom) + 4.5rem);
-}
-
-.fhi-diagram--fullscreen .fhi-diagram-fullscreen__close {
-    position: fixed;
-    top: calc(env(safe-area-inset-top) + 1rem);
-    right: calc(env(safe-area-inset-right) + 1rem);
-    z-index: 1100;
-}
-
-.fhi-diagram--fullscreen .fhi-diagram-fullscreen__close-bottom {
-    position: fixed;
-    right: calc(env(safe-area-inset-right) + 1rem);
-    bottom: calc(env(safe-area-inset-bottom) + 1rem);
-    z-index: 1100;
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -57,7 +57,7 @@ $square: 1;
     background: #fff;
     overflow: auto;
     box-sizing: border-box;
-    padding: 2rem;
+    padding: 32px;
     padding-bottom: 88px;
     min-height: 100vh;
 }
@@ -68,39 +68,50 @@ $square: 1;
 
 .fhi-diagram--fullscreen h1.h3 {
     font-size: 2.25rem;
-    padding-bottom: 2.9rem;
+    padding-bottom: 1.6rem;
 }
 
 .fhi-diagram--fullscreen .fhi-diagram-fullscreen__close {
     position: fixed;
-    top: 16px;
-    right: 16px;
+    top: 28px;
+    right: 28px;
     left: auto;
     z-index: 1060;
 }
 
 .fhi-diagram--fullscreen .fhi-diagram-fullscreen__close-bottom {
     position: fixed;
-    right: 16px;
-    bottom: 16px;
+    right: 32px;
+    bottom: 32px;
     left: auto;
     z-index: 1060;
 }
 
 @media (max-width: 600px) {
     .fhi-diagram--fullscreen {
-        padding: 12px;
+        padding-left: 32px;
+        padding-right: 32px;
         padding-bottom: 96px;
+        min-height: 100vh;
+    }
+
+    .fhi-diagram--fullscreen h1.h3 {
+        font-size: 1.7rem;
+        padding-bottom: 1rem;
     }
 
     .fhi-diagram--fullscreen .fhi-diagram-fullscreen__close {
-        top: 12px;
-        right: 12px;
+        top: 27px;
+        right: 25px;
+        left: auto;
+        z-index: 1060;
     }
 
     .fhi-diagram--fullscreen .fhi-diagram-fullscreen__close-bottom {
-        left: 12px;
-        right: 12px;
-        bottom: 12px;
+        left: 28px;
+        right: 28px;
+        bottom: 28px;
+        z-index: 1060;
+        margin: 4px;
     }
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -85,30 +85,30 @@ $square: 1;
     }
 }*/
 
-.fhi-diagram--fullscreen {
-    position: fixed;
-    inset: 0;
-    z-index: 1050;
-    background: #fff;
+@media (max-width: 576px) {
+    .fhi-diagram--fullscreen {
+        padding: 16px;
+        padding-bottom: 96px; // plass til "Lukk"
+    }
 
-    box-sizing: border-box;
-    padding: clamp(16px, 2vw, 32px);
+    .fhi-diagram--fullscreen {
+        .fhi-highcharts-chart highcharts-chart,
+        .fhi-highcharts-chart--map highcharts-chart {
+            height: 65vh;
+        }
+    }
 
-    padding-bottom: calc(clamp(16px, 2vw, 32px) + 64px);
+    .fhi-diagram-fullscreen__close {
+        top: 12px;
+        right: 12px;
+        transform: scale(1.1);
+    }
 
-    overflow: auto;
-}
-
-.fhi-diagram-fullscreen__close {
-    position: fixed;
-    top: calc(env(safe-area-inset-top) + clamp(12px, 2vw, 24px));
-    right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
-    z-index: 1060;
-}
-
-.fhi-diagram-fullscreen__close-bottom {
-    position: fixed;
-    right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
-    bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 2vw, 24px));
-    z-index: 1060;
+    .fhi-diagram-fullscreen__close-bottom {
+        left: 16px;
+        right: 16px;
+        bottom: 16px;
+        width: auto;
+        max-width: none;
+    }
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -50,7 +50,7 @@ $square: 1;
     }
 }
 
-.fhi-diagram--fullscreen {
+/*.fhi-diagram--fullscreen {
     position: fixed;
     inset: 0;
     z-index: 1050;
@@ -69,4 +69,33 @@ $square: 1;
         aspect-ratio: auto;
         height: 80vh;
     }
+}*/
+
+.fhi-diagram--fullscreen {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    background: #fff;
+
+    width: 100vw;
+    height: 100dvh;
+    overflow: auto;
+    overflow-x: hidden;
+
+    padding-top: calc(env(safe-area-inset-top) + 1rem);
+    padding-bottom: calc(env(safe-area-inset-bottom) + 4.5rem);
+}
+
+.fhi-diagram--fullscreen .fhi-diagram-fullscreen__close {
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + 1rem);
+    right: calc(env(safe-area-inset-right) + 1rem);
+    z-index: 1100;
+}
+
+.fhi-diagram--fullscreen .fhi-diagram-fullscreen__close-bottom {
+    position: fixed;
+    right: calc(env(safe-area-inset-right) + 1rem);
+    bottom: calc(env(safe-area-inset-bottom) + 1rem);
+    z-index: 1100;
 }

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -59,6 +59,7 @@ $square: 1;
     box-sizing: border-box;
     padding: 2rem;
     padding-bottom: 88px;
+    min-height: 100vh;
 }
 
 .fhi-diagram--fullscreen h1 {

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -49,3 +49,25 @@ $square: 1;
         }
     }
 }
+
+.fhi-diagram--fullscreen {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    background: #fff;
+    padding: 1rem;
+    overflow: auto;
+
+    .fhi-highcharts-chart,
+    .fhi-highcharts-chart--map {
+        max-width: none;
+        width: 100%;
+    }
+
+    .fhi-highcharts-chart highcharts-chart,
+    .fhi-highcharts-chart--map highcharts-chart {
+        max-height: none;
+        aspect-ratio: auto;
+        height: 80vh;
+    }
+}

--- a/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
+++ b/projects/fhi-angular-highcharts/src/styles/blocks/_fhi-highcharts-chart.block.scss
@@ -50,7 +50,7 @@ $square: 1;
     }
 }
 
-/*.fhi-diagram--fullscreen {
+.fhi-diagram--fullscreen {
     position: fixed;
     inset: 0;
     z-index: 1050;
@@ -69,21 +69,7 @@ $square: 1;
         aspect-ratio: auto;
         height: 80vh;
     }
-
-    .fhi-diagram-fullscreen__close {
-        position: fixed;
-        top: calc(env(safe-area-inset-top) + clamp(12px, 2vw, 24px));
-        right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
-        z-index: 1060;
-    }
-
-    .fhi-diagram-fullscreen__close-bottom {
-        position: fixed;
-        right: calc(env(safe-area-inset-right) + clamp(12px, 2vw, 24px));
-        bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 2vw, 24px));
-        z-index: 1060;
-    }
-}*/
+}
 
 @media (max-width: 576px) {
     .fhi-diagram--fullscreen {


### PR DESCRIPTION
Erstatter modal-basert fullskjerm (som opprettet en ekstra Highcharts-instans) med CSS-fullskjerm på samme graf. Da deles filtervalg mellom vanlig visning og fullskjerm.