### PR TITLE
924 fhi angular highcharts add back missing exported types

### DIFF
--- a/projects/fhi-angular-highcharts/CHANGELOG.md
+++ b/projects/fhi-angular-highcharts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - :bug: **Bugfix** Changed the way fullscreen view is rendered to prevent separate instances of the chart. [(#913)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/913)
 - :bug: **Bugfix** Fixed bug where outline for sections in map would render with too thick stroke. [(#922)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/922)
 - :tada: **Enhancement** Added new input for footnote in the footer. [(#921)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/921)
+- :bug: **Bugfix** Added explicit export for type that became inaccessible after upgrade to Angular 20 [(#924)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/926)
 
 # 7.0.0
 

--- a/projects/fhi-angular-highcharts/CHANGELOG.md
+++ b/projects/fhi-angular-highcharts/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+> Feb 6, 2026
+
+- :bug: **Bugfix** Changed the way fullscreen view is rendered to prevent separate instances of the chart. [(#913)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/913)
+- :bug: **Bugfix** Fixed bug where outline for sections in map would render with too thick stroke. [(#922)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/922)
+- :tada: **Enhancement** Added new input for footnote in the footer. [(#921)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/pull/921)
+
 # 7.0.0
 
 > Jan 22, 2026

--- a/projects/fhi-angular-highcharts/src/public-api.ts
+++ b/projects/fhi-angular-highcharts/src/public-api.ts
@@ -9,5 +9,6 @@ export * from './lib/models/fhi-diagram-flag.model';
 export * from './lib/models/fhi-diagram-options.model';
 export * from './lib/models/fhi-diagram-serie.model';
 export * from './lib/models/fhi-diagram-serie-data.model';
+export * from './lib/models/fhi-diagram-unit.model';
 
 export { FhiDiagramTypes } from './lib/constants-and-enums/fhi-diagram-types';


### PR DESCRIPTION
- Added explicit export for type that became inaccessible after updating to Angular 20.
- Updated changelog to show recent PR's since last release.