### PR TITLE
949 fhi angular highcharts endswith logikk i kommunekart kan gjøre at feil data vises

### DIFF
--- a/projects/fhi-angular-highcharts/CHANGELOG.md
+++ b/projects/fhi-angular-highcharts/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+> Mai 08, 2026
+
+- :bug: **Bugfix** Added extra validation to Kommunekart to prevent displaying wrong datapoints in the map. [(#949)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/issues/949)
+
 # 7.4.0
 
 > Apr 14, 2026

--- a/projects/fhi-angular-highcharts/src/lib/services/topo-json.service.ts
+++ b/projects/fhi-angular-highcharts/src/lib/services/topo-json.service.ts
@@ -72,6 +72,7 @@ export class TopoJsonService {
         geometry = geometries.find(
           (geometry: object) =>
             dataPoint.dataPointId &&
+            dataPoint.dataPointId.length === 4 &&
             geometry['properties']['hc-key'].endsWith(dataPoint.dataPointId),
         );
         break;

--- a/src/app/views/shared/dynamic-library-examples/example-components/highcharts/mock-data/12.dodsfall-hjerte-kar-etter-kommuner.ts
+++ b/src/app/views/shared/dynamic-library-examples/example-components/highcharts/mock-data/12.dodsfall-hjerte-kar-etter-kommuner.ts
@@ -22,6 +22,7 @@ export const DodsfallHjerteOgKarEtterKommune = [
       { name: 'Sauda', y: 132, dataPointId: '1135' },
       { name: 'Bokn', y: 941, dataPointId: '1145' },
       { name: 'Tysvær', y: 241, dataPointId: '1146' },
+      { name: 'Trøndelag', y: 90000, dataPointId: '50' },
     ],
   },
 ];


### PR DESCRIPTION
La til en quickfix med validering av lengde på datapoint ID for å forhindre at data for et fylke vises i kommunekartet.
(Tenker at dette skal refaktoreres i en mer robust løsning, men gjorde det på denne måten for å få ut en fix så fort som mulig siden kart er tilgjengelig for alle kilder nå.)