### PR TITLE
Release/fhi-angular-highcharts/7.4.1

### DIFF
--- a/projects/fhi-angular-highcharts/CHANGELOG.md
+++ b/projects/fhi-angular-highcharts/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Unreleased
+# 7.4.1
 
-> Mai 08, 2026
+> Mai 12, 2026
 
 - :bug: **Bugfix** Added extra validation to Kommunekart to prevent displaying wrong datapoints in the map. [(#949)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/issues/949)
 
-# 7.4.0
+## 7.4.0
 
 > Apr 14, 2026
 

--- a/projects/fhi-angular-highcharts/package.json
+++ b/projects/fhi-angular-highcharts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folkehelseinstituttet/angular-highcharts",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "publishConfig": {
     "tag": "latest"
   },


### PR DESCRIPTION
- :bug: **Bugfix** Added extra validation to Kommunekart to prevent displaying wrong datapoints in the map. [(#949)](https://github.com/folkehelseinstituttet/Fhi.Frontend.Demo/issues/949)